### PR TITLE
"gulp.run() has been deprecated."という警告が出ないよう対応

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,4 @@ gulp.task('narrative', function () {
         .pipe(gulp.dest("./narrative"));
 });
 
-gulp.task('default', function () {
-    gulp.run('base');
-});
+gulp.task('default', ['base']);


### PR DESCRIPTION
gulp 3.8.8を使っていると、

``` sh
$ gulp 
[00:46:49] Using gulpfile ~/git/LandingPages/gulpfile.js
[00:46:49] Starting 'default'...
gulp.run() has been deprecated. Use task dependencies or gulp.watch task triggering instead.
[00:46:49] Starting 'base'...
...(以下略)...
```

 という謎の警告が出るので、 http://efcl.info/2014/0125/res3630/ を参考に修正してみました（どうもgulp 3.5以降らしいです。ちなみにgulpをまともに使うのは初めてです :sweat_smile:  ）。
