### PR TITLE
謎のU+2028を削除、var定義文末尾に「;」を追加

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,11 +3,11 @@ var sass = require('gulp-ruby-sass');
 
 // Bower
 var config = {
-     bowerDir: './bower_components' ,
+    bowerDir: './bower_components',
     versions: {
       narrative: "1.0"
     }
-}
+};
 
 gulp.task('base', function () {
     return gulp.src('css/styles.scss')


### PR DESCRIPTION
gulpfile.jsの6行目、bowerDirの行の前後にU+2028が入っていて目立っていたので削除してみました。
また、var定義の末尾には`;`をつけろとjshintが言っていたので合わせて追加しています。
